### PR TITLE
enable row limit choice in reports' pages

### DIFF
--- a/advanced_reports/static/advanced_reports/js/advreport-angular.js
+++ b/advanced_reports/static/advanced_reports/js/advreport-angular.js
@@ -1,6 +1,8 @@
 angular.module('BackOfficeApp').controller('AdvancedReportCtrl', ['$scope', '$http', '$location', 'boUtils', 'boApi', function ($scope, $http, $location, boUtils, boApi){
     $scope.report = null;
     $scope.page_count = null;
+    $scope.row_limit_choices = [20, 50, 100];
+    $scope.row_limit = $scope.row_limit_choices[0];
     $scope.filters = {};
     $scope.applied_filters = {};
     $scope.search = $location.search() || {};
@@ -134,6 +136,12 @@ angular.module('BackOfficeApp').controller('AdvancedReportCtrl', ['$scope', '$ht
         return boUtils.keyCount($scope.selected);
     };
 
+    $scope.change_row_limit = function() {
+        $scope.search.row_limit = $scope.row_limit;
+        $scope.search.page = 1;
+        $scope.fetch_report();
+    }
+
     $scope.change_order = function(order_by) {
         var ascending = $scope.report.extra.order_by != order_by || !$scope.report.extra.ascending;
         $scope.search.order = (ascending ? '' : '-') + order_by;
@@ -161,6 +169,7 @@ angular.module('BackOfficeApp').controller('AdvancedReportCtrl', ['$scope', '$ht
         $scope.loader='search';
         $scope.filter = {};
         $scope.search = {order: $scope.search.order, page: 1};
+        $scope.row_limit = $scope.row_limit_choices[0];
         $scope.fetch_report();
     };
 

--- a/advanced_reports/templates/advanced_reports/backoffice/contrib/advanced-reports/advanced-report.html
+++ b/advanced_reports/templates/advanced_reports/backoffice/contrib/advanced-reports/advanced-report.html
@@ -124,6 +124,14 @@
                 <label><a href ng-show="has_applied_filters()" ng-click="remove_filters()">{% trans "show all" %}</a></label>
             </div>
         </form>
+
+        <form class="form-inline col-lg-4 col-md-5 col-sm-6" role="form">
+            <div class="form-group pull-right">
+                <select class="form-control" ng-options="value for value in row_limit_choices" ng-model="row_limit" ng-change="change_row_limit()">
+                </select>
+            </div>
+        </form>
+
         <div class="col-lg-4 col-md-5 col-sm-6 align-right">
             <form ng-submit="execute_multiple_action()" class="form-inline" role="form" ng-show="show_action_select()">
                 <div class="form-group">

--- a/advanced_reports/views.py
+++ b/advanced_reports/views.py
@@ -307,6 +307,9 @@ def _is_allowed_multiple_action(request, advreport, action):
 def api_list(request, advreport, ids=None):
     object_list, extra_context = advreport.get_object_list(request, ids=ids)
 
+    if 'row_limit' in request.GET:
+        advreport.items_per_page = int(request.GET['row_limit'])
+
     paginated = paginate(request, object_list, advreport.items_per_page)
 
     report = {

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -221,7 +221,6 @@ class ReportViewsTestCase(TestCase):
         response = self.client.post('/reports/api/simple/')
         self.assertIn('application/json', response['Content-Type'])
         data = json.loads(response.content)
-
         self.assertEqual(data['action_list_type'], 'links')
         self.assertEqual(data['extra'], {
             'ascending': True,
@@ -278,3 +277,9 @@ class ReportViewsTestCase(TestCase):
         self.assertEqual(data['search_fields'], ['username', 'first_name', 'last_name', 'email'])
         self.assertEqual(data['searchable_columns'], 'You can search by Username, First name, Last name, Email address')
         self.assertTrue(data['show_action_bar'])
+
+        row_limit = 50
+        response = self.client.post('/reports/api/simple/?row_limit=' + str(row_limit))
+        self.assertIn('application/json', response['Content-Type'])
+        data = json.loads(response.content)
+        self.assertEqual(data['items_per_page'], row_limit)


### PR DESCRIPTION
Allow the user to choose the number of the report's rows per page. Available values: 20, 50 and 100