### PR TITLE
Missing bo_model raising 404

### DIFF
--- a/advanced_reports/backoffice/base.py
+++ b/advanced_reports/backoffice/base.py
@@ -521,6 +521,9 @@ class ModelMixin(object):
         model_slug = request.view_params.get('model_slug')
         pk = request.view_params.get('pk')
         bo_model = self.get_model(slug=model_slug)
+        if not bo_model:
+            return HttpResponse(u"Page you've requested doesn't exist.", status=404)
+
         if not check_permission(request, bo_model.permission):
             return HttpResponse(u'You are not allowed to view this page.', status=403)
         obj = bo_model.model.objects.get(pk=pk)


### PR DESCRIPTION
In case someone mistype model name it will show 404 error message instead of raising 500 with attribute error.
